### PR TITLE
Add documentations for hook in isotope

### DIFF
--- a/docs/manual/developer/_index.de.md
+++ b/docs/manual/developer/_index.de.md
@@ -1,0 +1,13 @@
+---
+title: "Entwickler"
+description: "Informationen für Entwickler"
+aliases:
+    - /de/Entwickler/
+weight: 70
+---
+
+{{% notice note %}}
+Die Entwickler-Dokumentation ist nur in Englisch verfügbar.
+{{% /notice %}}
+
+[Entwicklerdokumentation auf Englisch](/en/developer/)

--- a/docs/manual/developer/_index.en.md
+++ b/docs/manual/developer/_index.en.md
@@ -1,0 +1,13 @@
+---
+title: "Developers"
+description: "Information for developers who want to extend Isotope eCommerce."
+aliases:
+    - /en/developer/
+weight: 70
+---
+
+{{% notice note %}}
+The developer docs are only available in english.
+{{% /notice %}}
+
+{{% children %}}

--- a/docs/manual/developer/hooks/_index.en.md
+++ b/docs/manual/developer/hooks/_index.en.md
@@ -1,0 +1,117 @@
+---
+title: "Hooks"
+description: "Developer Reference for Isotope Hooks."
+weight: 10
+---
+
+Hooks are entry points into the Isotope core (and some of its extension bundles). Have a look at the hook list of all available hooks. You can register your own callable logic that will be executed as soon as a certain point in the execution flow of the core will be reached. 
+
+## Registering hooks listeners
+
+There are two ways of registering hook listeners for isotope.
+
+### Service annotations
+
+{{< version "2.8" >}}
+
+The recommended way of registering hooks is to use service annotations:
+
+```php
+// src/EventListener/Isotope/AddProductToCollectionListener.php
+namespace App\EventListener\Isotope;
+
+use Isotope\Interfaces\IsotopeProduct
+use Isotope\Interfaces\IsotopeProductCollection;
+use Isotope\ServiceAnnotation\IsotopeHook;
+
+class AddProductToCollectionListener
+{
+    /**
+     * @IsotopeHook("addProductToCollection")
+     */
+    public function __invoke(IsotopeProduct $product, $quantity, IsotopeProductCollection $collection, array $config): int
+    {
+        // Your logic here
+
+        return $quantity;
+    }
+}
+```
+
+The legacy way of registering hooks is to register them in the global array in your `config.php` files:
+
+```php
+// config/config.php
+use App\EventListener\Isotope\AddProductToCollectionListener;
+
+$GLOBALS['ISO_HOOKS']['addProductToCollection'][] = [AddProductToCollectionListener::class, '__invoke'];
+```
+
+```php
+// src/EventListener/Isotope/AddProductToCollectionListener.php
+namespace App\EventListener\Isotope;
+
+use Isotope\Interfaces\IsotopeProduct
+use Isotope\Interfaces\IsotopeProductCollection;
+
+class AddProductToCollectionListener
+{
+    public function __invoke(IsotopeProduct $product, $quantity, IsotopeProductCollection $collection, array $config): int
+    {
+        // Your logic here
+
+        return $quantity;
+    }
+}
+```
+
+## Reference
+
+This is a list of all hooks available in isotope (as of version 2.8):
+
+- addAssetImportRegexp
+- addCollectionToTemplate
+- addProductToCollection
+- applyAdvancedFilters
+- calculatePrice
+- collectionLocked
+- compileCart
+- convertCurrency
+- copiedCollectionItems
+- copyCollectionItem
+- createFromProductCollection
+- deleteCollection
+- deleteItemFromCollection
+- downloadFromProductCollection
+- emailRecipientForCollection
+- findCategories
+- findSurchargesForCollection
+- generateDocumentNumber
+- generateDocumentTemplate
+- generateFilters
+- generateOrderLog
+- generateProduct
+- generateProductList
+- getAllowedProductIds
+- getOrderConditionsValue
+- getOrderNotificationTokens
+- initializePostsale
+- itemIsAvailable
+- modifyAddressFields
+- postAddProductToCollection
+- postCheckout
+- postDeleteCollection
+- postDeleteItemFromCollection
+- postOrderStatusUpdate
+- postUpdateItemInCollection
+- postUpdateProductInCollection
+- preCheckout
+- preOrderStatusUpdate
+- priceDisplay
+- productIsAvailable
+- saveCollection
+- updateAddressData
+- updateDraftOrder
+- updateItemInCollection
+- updateProductInCollection
+- useTaxRate


### PR DESCRIPTION
This PR add documentation for hooks. As there is currently no developers docs, it also introduces a section for that. 
I also add it only in english as this is common practice for developer notes, but I added a landing page for the german docs.

In the future we could also add pages for the single docs with description and examples, but for now this is a starting point.