### PR TITLE
Add documentation for 7 hooks

### DIFF
--- a/docs/manual/developer/_index.en.md
+++ b/docs/manual/developer/_index.en.md
@@ -6,8 +6,4 @@ aliases:
 weight: 70
 ---
 
-{{% notice note %}}
-The developer docs are only available in english.
-{{% /notice %}}
-
 {{% children %}}

--- a/docs/manual/developer/hooks/_index.en.md
+++ b/docs/manual/developer/hooks/_index.en.md
@@ -102,7 +102,7 @@ This is a list of all hooks available in isotope (as of version 2.8):
 - initializePostsale
 - itemIsAvailable
 - modifyAddressFields
-- postAddProductToCollection
+- [postAddProductToCollection](postAddProductToCollection)
 - [postCheckout](postCheckout)
 - postDeleteCollection
 - postDeleteItemFromCollection

--- a/docs/manual/developer/hooks/_index.en.md
+++ b/docs/manual/developer/hooks/_index.en.md
@@ -71,7 +71,7 @@ This is a list of all hooks available in isotope (as of version 2.8):
 
 - addAssetImportRegexp
 - addCollectionToTemplate
-- addProductToCollection
+- [addProductToCollection](addProductToCollection/_index.en.md)
 - applyAdvancedFilters
 - calculatePrice
 - collectionLocked

--- a/docs/manual/developer/hooks/_index.en.md
+++ b/docs/manual/developer/hooks/_index.en.md
@@ -6,6 +6,9 @@ weight: 10
 
 Hooks are entry points into the Isotope core (and some of its extension bundles). Have a look at the hook list of all available hooks. You can register your own callable logic that will be executed as soon as a certain point in the execution flow of the core will be reached. 
 
+
+{{%expand "Registering hooks listeners" %}}
+
 ## Registering hooks listeners
 
 There are two ways of registering hook listeners for isotope.
@@ -64,6 +67,7 @@ class AddProductToCollectionListener
     }
 }
 ```
+{{% /expand%}}
 
 ## Reference
 
@@ -71,7 +75,7 @@ This is a list of all hooks available in isotope (as of version 2.8):
 
 - addAssetImportRegexp
 - addCollectionToTemplate
-- [addProductToCollection](addProductToCollection/_index.en.md)
+- [addProductToCollection](addProductToCollection)
 - applyAdvancedFilters
 - calculatePrice
 - collectionLocked
@@ -99,13 +103,13 @@ This is a list of all hooks available in isotope (as of version 2.8):
 - itemIsAvailable
 - modifyAddressFields
 - postAddProductToCollection
-- postCheckout
+- [postCheckout](postCheckout)
 - postDeleteCollection
 - postDeleteItemFromCollection
 - postOrderStatusUpdate
 - postUpdateItemInCollection
 - postUpdateProductInCollection
-- preCheckout
+- [preCheckout](preCheckout)
 - preOrderStatusUpdate
 - priceDisplay
 - productIsAvailable

--- a/docs/manual/developer/hooks/_index.en.md
+++ b/docs/manual/developer/hooks/_index.en.md
@@ -110,12 +110,12 @@ This is a list of all hooks available in isotope (as of version 2.8):
 - postUpdateItemInCollection
 - postUpdateProductInCollection
 - [preCheckout](preCheckout)
-- preOrderStatusUpdate
+- [preOrderStatusUpdate](preOrderStatusUpdate)
 - priceDisplay
 - productIsAvailable
 - saveCollection
 - updateAddressData
 - updateDraftOrder
-- updateItemInCollection
+- [updateItemInCollection](updateItemInCollection)
 - updateProductInCollection
 - useTaxRate

--- a/docs/manual/developer/hooks/_index.en.md
+++ b/docs/manual/developer/hooks/_index.en.md
@@ -94,7 +94,7 @@ This is a list of all hooks available in isotope (as of version 2.8):
 - generateDocumentTemplate
 - generateFilters
 - generateOrderLog
-- generateProduct
+- [generateProduct](generateProduct)
 - generateProductList
 - getAllowedProductIds
 - getOrderConditionsValue

--- a/docs/manual/developer/hooks/addProductToCollection/_index.en.md
+++ b/docs/manual/developer/hooks/addProductToCollection/_index.en.md
@@ -38,7 +38,7 @@ use Isotope\ServiceAnnotation\IsotopeHook;
  */
 class AddProductToCollectionListener 
 {
-    public function __invoke(IsotopeProduct $product, $quantity, IsotopeProductCollection $collection, array $config): int
+    public function __invoke(IsotopeProduct $product, int $quantity, IsotopeProductCollection $collection, array $config): int
     {
         // example for allowing max 5 items per product
         if ($quantity > 5) {

--- a/docs/manual/developer/hooks/addProductToCollection/_index.en.md
+++ b/docs/manual/developer/hooks/addProductToCollection/_index.en.md
@@ -1,6 +1,5 @@
 ---
 title: "addProductToCollection"
-hidden: true
 ---
 
 The `addProductToCollection` hook is triggered every time a product is added to the cart.

--- a/docs/manual/developer/hooks/addProductToCollection/_index.en.md
+++ b/docs/manual/developer/hooks/addProductToCollection/_index.en.md
@@ -1,0 +1,51 @@
+---
+title: "addProductToCollection"
+---
+
+## Parameters
+
+1. \Isotope\Interfaces\IsotopeProduct `$product`
+   
+    The product that is added to the collection.
+
+2. int `$quantity`
+   
+    The quantity of the product that is added to the collection.
+
+3. \Isotope\Interfaces\IsotopeProductCollection `$collection`
+   
+    The collection the product is added to.
+
+4. array `$config`
+   
+    The model configuration.
+
+## Example
+
+```php
+// src/EventListener/Isotope/AddProductToCollectionListener.php
+namespace App\EventListener\Isotope;
+
+use Isotope\Interfaces\IsotopeProduct;
+use Isotope\Interfaces\IsotopeProductCollection;
+use Isotope\ServiceAnnotation\IsotopeHook;
+
+/**
+ * @IsotopeHook("addProductToCollection")
+ */
+class AddProductToCollectionListener 
+{
+    public function __invoke(IsotopeProduct $product, $quantity, IsotopeProductCollection $collection, array $config): int
+    {
+        // example for allowing max 5 items per product
+        if ($quantity > 5) {
+            return 5;
+        }
+        return $quantity
+    }
+}
+```
+
+## References
+
+* [\Isotope\Model\ProductCollection#L1053-L1059](https://github.com/isotope/core/blob/2.8/system/modules/isotope/library/Isotope/Model/ProductCollection.php#L1053-L1059)

--- a/docs/manual/developer/hooks/addProductToCollection/_index.en.md
+++ b/docs/manual/developer/hooks/addProductToCollection/_index.en.md
@@ -1,6 +1,10 @@
 ---
 title: "addProductToCollection"
+hidden: true
 ---
+
+The `addProductToCollection` hook is triggered every time a product is added to the cart.
+It allows manipulating the number of items added to the cart.
 
 ## Parameters
 

--- a/docs/manual/developer/hooks/generateProduct/_index.en.md
+++ b/docs/manual/developer/hooks/generateProduct/_index.en.md
@@ -1,6 +1,5 @@
 ---
 title: "generateProduct"
-hidden: true
 ---
 
 The `generateProduct` hook is called when the product page (reader) is rendered. It allows to add custom information to the product page.
@@ -11,7 +10,7 @@ The `generateProduct` hook is called when the product page (reader) is rendered.
    
     The template object.
 
-1. \Isotope\Model\Product\AbstractProduct `$product`
+1. \Isotope\Interfaces\IsotopeProduct `$product`
    
     The product model.
 
@@ -30,7 +29,7 @@ use Isotope\Template;
  */
 class GenerateProductListener
 {
-    public function __invoke(Template $template, AbstractProduct $product): void
+    public function __invoke(Template $template, IsotopeProduct $product): void
     {
         $template->customMessage = 'We currently have more orders than usual. Please expect longer waiting times.';
     }

--- a/docs/manual/developer/hooks/generateProduct/_index.en.md
+++ b/docs/manual/developer/hooks/generateProduct/_index.en.md
@@ -1,0 +1,42 @@
+---
+title: "generateProduct"
+hidden: true
+---
+
+The `generateProduct` hook is called when the product page (reader) is rendered. It allows to add custom information to the product page.
+
+## Parameters
+
+1. \Isotope\Template `$template`
+   
+    The template object.
+
+1. \Isotope\Model\Product\AbstractProduct `$product`
+   
+    The product model.
+
+## Example
+
+```php
+// src/EventListener/Isotope/GenerateProductListener.php
+namespace App\EventListener\Isotope;
+
+use Isotope\Model\Product\AbstractProduct;
+use Isotope\ServiceAnnotation\IsotopeHook;
+use Isotope\Template;
+
+/**
+ * @IsotopeHook("generateProduct")
+ */
+class GenerateProductListener
+{
+    public function __invoke(Template $template, AbstractProduct $product): void
+    {
+        $template->customMessage = 'We currently have more orders than usual. Please expect longer waiting times.';
+    }
+}
+```
+
+## References
+
+* [\Isotope\Model\Product\Standard#L643-L647](https://github.com/isotope/core/blob/2.8/system/modules/isotope/library/Isotope/Model/Product/Standard.php#L643-L647)

--- a/docs/manual/developer/hooks/postAddProductToCollection/_index.en.md
+++ b/docs/manual/developer/hooks/postAddProductToCollection/_index.en.md
@@ -13,7 +13,7 @@ The `postAddProductToCollection` hook is triggered after a product is added to t
 
 2. int `$quantity`
    
-    The quantity of the product that is added to the collection.
+    The quantity of the product that was added to the collection.
 
 3. \Isotope\Interfaces\IsotopeProductCollection `$collection`
    

--- a/docs/manual/developer/hooks/postAddProductToCollection/_index.en.md
+++ b/docs/manual/developer/hooks/postAddProductToCollection/_index.en.md
@@ -1,0 +1,50 @@
+---
+title: "postAddProductToCollection"
+---
+
+The `postAddProductToCollection` hook is triggered after a product is added to the cart and can be used to perform additional actions.
+
+
+## Parameters
+
+1. \Isotope\Interfaces\IsotopeProduct `$product`
+   
+    The product that is added to the collection.
+
+2. int `$quantity`
+   
+    The quantity of the product that is added to the collection.
+
+3. \Isotope\Interfaces\IsotopeProductCollection `$collection`
+   
+    The collection the product is added to.
+
+4. array `$config`
+   
+    The model configuration.
+
+## Example
+
+```php
+// src/EventListener/Isotope/PostAddProductToCollectionListener.php
+namespace App\EventListener\Isotope;
+
+use Isotope\Interfaces\IsotopeProduct;
+use Isotope\Interfaces\IsotopeProductCollection;
+use Isotope\ServiceAnnotation\IsotopeHook;
+
+/**
+ * @IsotopeHook("postAddProductToCollection")
+ */
+class PostAddProductToCollectionListener 
+{
+    public function __invoke(IsotopeProduct $product, $quantity, IsotopeProductCollection $collection, array $config): void
+    {
+        // Do something …
+    }
+}
+```
+
+## References
+
+* [\Isotope\Model\ProductCollection#L1112-L1118](https://github.com/isotope/core/blob/2.8/system/modules/isotope/library/Isotope/Model/ProductCollection.php#L1112-L1118)

--- a/docs/manual/developer/hooks/postAddProductToCollection/_index.en.md
+++ b/docs/manual/developer/hooks/postAddProductToCollection/_index.en.md
@@ -9,7 +9,7 @@ The `postAddProductToCollection` hook is triggered after a product is added to t
 
 1. \Isotope\Interfaces\IsotopeProduct `$product`
    
-    The product that is added to the collection.
+    The product that was added to the collection.
 
 2. int `$quantity`
    

--- a/docs/manual/developer/hooks/postAddProductToCollection/_index.en.md
+++ b/docs/manual/developer/hooks/postAddProductToCollection/_index.en.md
@@ -17,7 +17,7 @@ The `postAddProductToCollection` hook is triggered after a product is added to t
 
 3. \Isotope\Interfaces\IsotopeProductCollection `$collection`
    
-    The collection the product is added to.
+    The collection the product was added to.
 
 4. array `$config`
    

--- a/docs/manual/developer/hooks/postCheckout/_index.en.md
+++ b/docs/manual/developer/hooks/postCheckout/_index.en.md
@@ -1,0 +1,47 @@
+---
+title: "postCheckout"
+hidden: true
+---
+
+The `postCheckout` hook is called after the checkout process is finished.
+
+## Parameters
+
+1. \Isotope\Model\ProductCollection\Order `$order`
+   
+    The order object.
+
+1. \Isotope\Module\Checkout `$module`
+   
+    The checkout module.
+
+## Example
+
+```php
+// src/EventListener/Isotope/PostCheckoutListener.php
+namespace App\EventListener\Isotope;
+
+use Isotope\Model\ProductCollection\Order;
+use Isotope\Module\Checkout;
+use Isotope\ServiceAnnotation\IsotopeHook;
+
+/**
+ * @IsotopeHook("postCheckout")
+ */
+class PostCheckoutListener
+{
+    public function __invoke(Order $order, Checkout $module): void
+    {
+        if (count($order->getItems()) > 5) {
+            // only allow max 5 articles per order
+            return false;
+        }
+
+        return true;
+    }
+}
+```
+
+## References
+
+* [\Isotope\Module\Checkout#L236-L245](https://github.com/isotope/core/blob/2.8/system/modules/isotope/library/Isotope/Module/Checkout.php#L236-L245)

--- a/docs/manual/developer/hooks/postCheckout/_index.en.md
+++ b/docs/manual/developer/hooks/postCheckout/_index.en.md
@@ -10,9 +10,9 @@ The `postCheckout` hook is called after the checkout process is finished.
    
     The order object.
 
-1. \Isotope\Module\Checkout `$module`
-   
-    The checkout module.
+2. `array $tokens`
+
+    The notification center tokens.
 
 ## Example
 
@@ -29,12 +29,9 @@ use Isotope\ServiceAnnotation\IsotopeHook;
  */
 class PostCheckoutListener
 {
-    public function __invoke(Order $order, Checkout $module): void
+    public function __invoke(Order $order, array $tokens): void
     {
-        if (count($order->getItems()) > 5) {
-            // only allow max 5 articles per order
-            return false;
-        }
+        // Do something ...
 
         return true;
     }

--- a/docs/manual/developer/hooks/postCheckout/_index.en.md
+++ b/docs/manual/developer/hooks/postCheckout/_index.en.md
@@ -1,6 +1,5 @@
 ---
 title: "postCheckout"
-hidden: true
 ---
 
 The `postCheckout` hook is called after the checkout process is finished.

--- a/docs/manual/developer/hooks/postCheckout/_index.en.md
+++ b/docs/manual/developer/hooks/postCheckout/_index.en.md
@@ -32,8 +32,6 @@ class PostCheckoutListener
     public function __invoke(Order $order, array $tokens): void
     {
         // Do something ...
-
-        return true;
     }
 }
 ```

--- a/docs/manual/developer/hooks/preCheckout/_index.en.md
+++ b/docs/manual/developer/hooks/preCheckout/_index.en.md
@@ -1,0 +1,56 @@
+---
+title: "preCheckout"
+hidden: true
+---
+
+The `preCheckout` hook is called before the checkout process is started.
+It allows to abort the checkout process.
+
+## Parameters
+
+1. \Isotope\Model\ProductCollection\Order|null `$order`
+   
+    The order object.
+
+1. \Isotope\Module\Checkout `$module`
+   
+    The checkout module.
+
+## Return Values
+
+The hook must return a boolean value. If `false` is returned, the checkout process is aborted.
+
+## Example
+
+```php
+// src/EventListener/Isotope/PreCheckoutListener.php
+namespace App\EventListener\Isotope;
+
+use Isotope\Model\ProductCollection\Order;
+use Isotope\Module\Checkout;
+use Isotope\ServiceAnnotation\IsotopeHook;
+
+/**
+ * @IsotopeHook("preCheckout")
+ */
+class PreCheckoutListener
+{
+    public function __invoke(?Order $order, Checkout $module): bool
+    {
+        if (!$order) {
+            return true;
+        }
+        
+        if (count($order->getItems()) > 5) {
+            // only allow max 5 articles per order
+            return false;
+        }
+
+        return true;
+    }
+}
+```
+
+## References
+
+* [\Isotope\Model\ProductCollection\Order#L235-L244](https://github.com/isotope/core/blob/2.8/system/modules/isotope/library/Isotope/Model/ProductCollection/Order.php#L235-L244)

--- a/docs/manual/developer/hooks/preCheckout/_index.en.md
+++ b/docs/manual/developer/hooks/preCheckout/_index.en.md
@@ -1,6 +1,5 @@
 ---
 title: "preCheckout"
-hidden: true
 ---
 
 The `preCheckout` hook is called before the checkout process is started.

--- a/docs/manual/developer/hooks/preOrderStatusUpdate/_index.en.md
+++ b/docs/manual/developer/hooks/preOrderStatusUpdate/_index.en.md
@@ -1,6 +1,5 @@
 ---
 title: "preOrderStatusUpdate"
-hidden: true
 ---
 
 The `preOrderStatusUpdate` hook is called before the order status is updated.

--- a/docs/manual/developer/hooks/preOrderStatusUpdate/_index.en.md
+++ b/docs/manual/developer/hooks/preOrderStatusUpdate/_index.en.md
@@ -1,0 +1,55 @@
+---
+title: "preOrderStatusUpdate"
+hidden: true
+---
+
+The `preOrderStatusUpdate` hook is called before the order status is updated.
+
+## Parameters
+
+1. \Isotope\Model\ProductCollection\Order `$order` 
+
+   The order model.
+
+2. \Isotope\Model\OrderStatus `$newStatus`
+
+    The new order status.
+
+3. `array $updates`
+
+    The order status updates.
+
+## Return Values
+
+Return `true` to cancel the order status change.
+
+## Example
+
+```php
+// src/EventListener/Isotope/PreOrderStatusUpdateListener.php
+namespace App\EventListener\Isotope;
+
+use Isotope\Model\OrderStatus;
+use Isotope\Model\ProductCollection\Order;
+use Isotope\ServiceAnnotation\IsotopeHook;
+
+/**
+ * @IsotopeHook("preOrderStatusUpdate")
+ */
+class PreOrderStatusUpdateListener
+{
+    public function __invoke(Order $order, OrderStatus $newsStatus, array $updates): bool
+    {
+        // Cancel the order status change if the order is not paid.
+        if (!$order->isPaid()) {
+            return true;
+        }
+
+        return false;
+    }
+}
+```
+
+## References
+
+* [\Isotope\Model\ProductCollection\Order#L308-L318](https://github.com/isotope/core/blob/2.8/system/modules/isotope/library/Isotope/Model/ProductCollection/Order.php##L308-L318)

--- a/docs/manual/developer/hooks/updateItemInCollection/_index.en.md
+++ b/docs/manual/developer/hooks/updateItemInCollection/_index.en.md
@@ -1,6 +1,5 @@
 ---
 title: "updateItemInCollection"
-hidden: true
 ---
 
 The `updateItemInCollection` hook is called when an item is added or updated in the collection.

--- a/docs/manual/developer/hooks/updateItemInCollection/_index.en.md
+++ b/docs/manual/developer/hooks/updateItemInCollection/_index.en.md
@@ -1,0 +1,52 @@
+---
+title: "updateItemInCollection"
+hidden: true
+---
+
+The `updateItemInCollection` hook is called when an item is added or updated in the collection.
+
+## Parameters
+
+1. \Isotope\Model\ProductCollectionItem `$item` 
+    
+   The item that is added or updated.
+
+2. array `$set`
+
+    The set of data that is used to update the item.
+
+3. \Isotope\Model\ProductCollection `$collection`
+
+    The collection the item is added or updated in.
+
+
+## Return Values
+
+The return value is the set of data that is used to update the item.
+
+## Example
+
+```php
+// src/EventListener/Isotope/UpdateItemInCollectionListener.php
+namespace App\EventListener\Isotope;
+
+use Isotope\Model\ProductCollection;
+use Isotope\Model\ProductCollectionItem;
+use Isotope\ServiceAnnotation\IsotopeHook;
+
+/**
+ * @IsotopeHook("updateItemInCollection")
+ */
+class UpdateItemInCollectionListener
+{
+    
+    public function __invoke(ProductCollectionItem $item, array $set, ProductCollection $collection): array
+    {
+        return $set;
+    }
+}
+```
+
+## References
+
+* [\Isotope\Model\ProductCollection#L1198-L1208](https://github.com/isotope/core/blob/2.8/system/modules/isotope/library/Isotope/Model/ProductCollection.php#L1198-L1208)


### PR DESCRIPTION
This PR add documentation for ~~5~~ 7 hooks. It also add an expand tag around the hook registration part as the hook reference is IMHO the typical use case why people open the docs. 

The structure of hook documentation is copied from the contao docs :)

As I'm relative new to isotope, it would be great if someone could read over the descriptions and add missing points, since me and copilot not knowing all depths of isotope :smile_cat: 
